### PR TITLE
Deutsche Bahn version light

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ La publicité
 - [CNN](http://lite.cnn.com/en)
 - [Reddit](https://old.reddit.com/)
 - [OUI Léger](https://addons.mozilla.org/fr/firefox/addon/oui-light/) - Extension firefox pour rendre Oui.sncf plus léger.
+- [Deutsche Bahn](https://reiseauskunft.bahn.de/bin/query.exe/el)
 
 ### Sites minimalistes
 


### PR DESCRIPTION
Souvent cité par Frédéric Bordage, le site de la compagnie ferroviaire Allemande Deutche Bahn continue de proposer et de maintenir une version CGI hyper légère  de son site pour la recherche de trajets.

> La Deutsche Bahn, qui fait rouler des trains en Allemagne, propose deux sites web qui donnent les horaires des trains.
> 
> Le premier, qui date de 1998, pèse moins de 3 Ko. Il est donc rapide comme l’éclair, même en 3G.
> 
> Le second site web, moderne, pèse 1 353 fois plus lourd ! Autant dire qu’il vaut mieux avoir un ordinateur dernier cri connecté à une fibre optique pour l’utiliser confortablement.